### PR TITLE
fix: issues about unit tests

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -39,6 +39,7 @@ Route::prefix('v1')->group(function() {
         Route::middleware('permission:create categories')->post('/categories', [CategoryController::class, 'store']);
         Route::middleware('permission:edit categories')->put('/categories/{category}', [CategoryController::class, 'update']);
         Route::middleware('permission:delete categories')->delete('/categories/{category}', [CategoryController::class, 'destroy']);
+        Route::get('/categories/{category}/children', [CategoryController::class, 'children']);
 
         // Course routes with permission checks
         Route::get('/courses', [CourseController::class, 'index']);

--- a/tests/Feature/CourseTest.php
+++ b/tests/Feature/CourseTest.php
@@ -3,8 +3,27 @@
 use App\Models\Course;
 use App\Models\Category;
 use App\Models\Tag;
+use App\Models\User;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function() {
+    $createPermission = Permission::firstOrCreate(['name' => 'create courses']);
+    $editPermission = Permission::firstOrCreate(['name' => 'edit courses']);
+    $deletePermission = Permission::firstOrCreate(['name' => 'delete courses']);
+
+    $role = Role::firstOrCreate(['name' => 'mentor']);
+    $role->syncPermissions([$createPermission, $editPermission, $deletePermission]);
+
+    $this->user = User::factory()->create();
+    $this->user->assignRole('mentor');
+
+    $this->token = auth()->login($this->user);
+
+    $this->actingAs($this->user, 'api');
+});
 
 test('can get all courses', function() {
     // Create some categories and tags first

--- a/tests/Feature/TagTest.php
+++ b/tests/Feature/TagTest.php
@@ -1,8 +1,27 @@
 <?php
 
 use App\Models\Tag;
+use App\Models\User;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
 
 uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function() {
+    $createPermission = Permission::firstOrCreate(['name' => 'create tags']);
+    $editPermission = Permission::firstOrCreate(['name' => 'edit tags']);
+    $deletePermission = Permission::firstOrCreate(['name' => 'delete tags']);
+
+    $role = Role::firstOrCreate(['name' => 'admin']);
+    $role->syncPermissions([$createPermission, $editPermission, $deletePermission]);
+
+    $this->user = User::factory()->create();
+    $this->user->assignRole('admin');
+
+    $this->token = auth()->login($this->user);
+
+    $this->actingAs($this->user, 'api');
+});
 
 test('can get all tags', function() {
     Tag::factory(5)->create();

--- a/tests/Feature/VideoTest.php
+++ b/tests/Feature/VideoTest.php
@@ -18,14 +18,15 @@ beforeEach(function() {
     Permission::create(['name' => 'manage courses']);
     Permission::create(['name' => 'create courses']);
     Permission::create(['name' => 'edit courses']);
+    Permission::create(['name' => 'delete courses']);
 
     // Create mentor role
-    $role = Role::create(['name' => 'instructor']);
-    $role->givePermissionTo(['create courses', 'edit courses', 'manage courses']);
+    $role = Role::create(['name' => 'mentor']);
+    $role->givePermissionTo(['create courses', 'edit courses', 'manage courses', 'delete courses']);
 
-    // Create user with instructor role
+    // Create user with mentor role
     $this->user = User::factory()->create();
-    $this->user->assignRole('instructor');
+    $this->user->assignRole('mentor');
 
     // Create course
     $this->course = Course::factory()->create();
@@ -37,7 +38,7 @@ beforeEach(function() {
     $this->videoFile = UploadedFile::fake()->create('sample.mp4', 1024, 'video/mp4');
 });
 
-test('instructor can add video to course', function () {
+test('mentor can add video to course', function () {
     $response = $this->withHeaders([
         'Authorization' => 'Bearer ' . $this->token,
     ])->postJson("/api/v1/courses/{$this->course->id}/videos", [
@@ -65,7 +66,7 @@ test('instructor can add video to course', function () {
     Storage::disk('public')->assertExists($video->file_path);
 });
 
-test('instructor can get course videos', function () {
+test('mentor can get course videos', function () {
     // Create some videos
     $video1 = Video::create([
         'course_id' => $this->course->id,
@@ -93,7 +94,7 @@ test('instructor can get course videos', function () {
 });
 
 
-test('instructor can update video details', function () {
+test('mentor can update video details', function () {
     $video = Video::create([
         'course_id' => $this->course->id,
         'title' => 'Original Title',
@@ -121,7 +122,7 @@ test('instructor can update video details', function () {
     ]);
 });
 
-test('instructor can update video with new file', function () {
+test('mentor can update video with new file', function () {
     $video = Video::create([
         'course_id' => $this->course->id,
         'title' => 'Original Video',
@@ -156,7 +157,7 @@ test('instructor can update video with new file', function () {
     Storage::disk('public')->assertExists($updatedVideo->file_path);
 });
 
-test('instructor can delete video', function () {
+test('mentor can delete video', function () {
     $video = Video::create([
         'course_id' => $this->course->id,
         'title' => 'Temporary Video',


### PR DESCRIPTION
This pull request includes several changes to the `routes/api.php` file and various test files to enhance the functionality and permissions for handling categories, courses, tags, and videos. The most important changes include adding a new route for fetching category children, setting up permissions and roles in tests, and updating test assertions to match the new structure.

### Route Enhancements:
* Added a new route to fetch children of a specific category in `routes/api.php`.

### Test Setup Enhancements:
* Added `beforeEach` setup in `CategoryTest.php`, `CourseTest.php`, and `TagTest.php` to create permissions, roles, and assign roles to users. [[1]](diffhunk://#diff-d1eaf5eee5fe559b1b55d216345d03efc73dd83f30a3c95f4fe5f764e3d6e42aR4-R25) [[2]](diffhunk://#diff-d9cef16c804745f7798355eff510b39fd208238495fcddea93a58480274eb27dR6-R27) [[3]](diffhunk://#diff-fec8a5ad2538f1604f09794d53e654ea05baba84e07a4a959c6424554368a7dfR4-R25)

### Test Assertion Updates:
* Updated JSON structure assertions in `CategoryTest.php` to match the new data structure. [[1]](diffhunk://#diff-d1eaf5eee5fe559b1b55d216345d03efc73dd83f30a3c95f4fe5f764e3d6e42aR48-R53) [[2]](diffhunk://#diff-d1eaf5eee5fe559b1b55d216345d03efc73dd83f30a3c95f4fe5f764e3d6e42aL116-R143)

### Role and Permission Adjustments:
* Changed the role from `instructor` to `mentor` and added the `delete courses` permission in `VideoTest.php`. [[1]](diffhunk://#diff-7a744244d18e0a1dca6be97550342e4e00b67403188a70e8494428185f25a2ebR21-R29) [[2]](diffhunk://#diff-7a744244d18e0a1dca6be97550342e4e00b67403188a70e8494428185f25a2ebL40-R41) [[3]](diffhunk://#diff-7a744244d18e0a1dca6be97550342e4e00b67403188a70e8494428185f25a2ebL68-R69) [[4]](diffhunk://#diff-7a744244d18e0a1dca6be97550342e4e00b67403188a70e8494428185f25a2ebL96-R97) [[5]](diffhunk://#diff-7a744244d18e0a1dca6be97550342e4e00b67403188a70e8494428185f25a2ebL124-R125) [[6]](diffhunk://#diff-7a744244d18e0a1dca6be97550342e4e00b67403188a70e8494428185f25a2ebL159-R160)